### PR TITLE
clflush(P) moved outside of the timing measurement procedure

### DIFF
--- a/libs/cache/latency.c
+++ b/libs/cache/latency.c
@@ -123,8 +123,9 @@ i64 detect_dram_latency(u32 repeats) {
 
     _maccess(target);
     for (i = 0; i < repeats; i++) {
-        _rdtscp_aux(&aux_before);
         _clflush(target);
+        _mfence();
+        _rdtscp_aux(&aux_before);
         i64 lat = _time_maccess(target);
         _rdtscp_aux(&aux_after);
         if (aux_after == aux_before) {


### PR DESCRIPTION
`clflush` should be done before the access is timed. In virtualized environments the delay introduced by `clflush`
within the measurement window is very visible, although this is typically not the case when outside of VMs.﻿
