### PR TITLE
Parallel eviction set construction

### DIFF
--- a/include/cache/evset.h
+++ b/include/cache/evset.h
@@ -41,7 +41,7 @@ struct evset_stats {
     u64 bctr_duras[MAX_BACKTRACK_REC], useful_bctr_duras[MAX_BACKTRACK_REC];
 };
 
-extern struct evset_stats _evset_stats;
+extern __thread struct evset_stats _evset_stats;
 
 static inline void inc_retry(u64 retry) {
     if (retry < MAX_RETRY_REC - 1) {

--- a/libs/cache/evset.c
+++ b/libs/cache/evset.c
@@ -13,7 +13,7 @@ static const bool _dbg = false;
         }                                                                      \
     } while (0)
 
-struct evset_stats _evset_stats;
+__thread struct evset_stats _evset_stats;
 
 EVBuildConfig def_l1d_ev_config, def_l2_ev_config;
 

--- a/src/README.md
+++ b/src/README.md
@@ -132,8 +132,12 @@ If `<number of offsets>` is set to `0`,
 the program constructs eviction sets for every LLC/SF set in the system;
 otherwise, the program randomly selects `<number of offsets>` offsets
 and construct eviction sets for LLC/SF sets at those offsets.
-This program takes the same optional arguments as the `osc-single-evset`, except for having no `--hugepage` option and an additional `-L`/`--total-run-time-limit` option
-that controls how long the program can run in minutes.
+This program takes the same optional arguments as the `osc-single-evset`, except for having no `--hugepage` option and two additional options:
+`-L`/`--total-run-time-limit` controls how long the program can run in minutes,
+and `-P`/`--parallel-construction` controls LLC/SF construction parallelism.
+The `-P` option takes an even number of cores, using one construction thread
+and one helper thread per pair; use `0` to select the largest even number of
+cores reported by the system.
 
 ### Outputs
 Here's a segmented sample output from running

--- a/src/README.md
+++ b/src/README.md
@@ -137,7 +137,7 @@ This program takes the same optional arguments as the `osc-single-evset`, except
 and `-P`/`--parallel-construction` controls LLC/SF construction parallelism.
 The `-P` option takes an even number of cores, using one construction thread
 and one helper thread per pair; use `0` to select the largest even number of
-cores reported by the system.
+non-SMT cores available to the process.
 
 ### Outputs
 Here's a segmented sample output from running

--- a/src/osc-multi-evset.c
+++ b/src/osc-multi-evset.c
@@ -13,10 +13,13 @@ static size_t extra_cong = 1;
 static size_t max_tries = 10, max_backtrack = 20, max_timeout = 0;
 static size_t total_runtime_limit = 0; // in minutes
 static bool l2_filter = true, single_thread = false;
+static size_t n_para = 0;
 static size_t num_l2sets;
 static helper_thread_ctrl hctrl;
 
 #define NUM_OFFSETS (PAGE_SIZE / CL_SIZE)
+
+static void free_evcands_complex(EVCands ***complex);
 
 EVSet ***build_l2_evsets_all() {
     u64 start = time_ns();
@@ -126,9 +129,17 @@ EVCands ***build_evcands_all(EVBuildConfig *conf, EVSet ***l2evsets) {
 
     start = time_ns();
     EVCands ***cands_complex = calloc(NUM_OFFSETS, sizeof(*cands_complex));
+    if (!cands_complex) {
+        _error("Failed to allocate EVCands complex\n");
+        goto err;
+    }
     for (u32 n = 0; n < NUM_OFFSETS; n++) {
         u32 offset = n * CL_SIZE;
         cands_complex[n] = calloc(num_l2sets, sizeof(EVCands *));
+        if (!cands_complex[n]) {
+            _error("Failed to allocate EVCands sub-complex\n");
+            goto err;
+        }
         for (u32 i = 0; i < num_l2sets; i++) {
             if (n == 0) {
                 if (l2_filter) {
@@ -139,22 +150,32 @@ EVCands ***build_evcands_all(EVBuildConfig *conf, EVSet ***l2evsets) {
                 EVCands *cands = evcands_new(detected_l3, &conf->cands_config,
                                              base_cands->evb);
                 if (!cands) {
-                    return NULL;
+                    goto err;
                 }
 
                 if (evcands_populate(offset, cands, &conf->cands_config)) {
-                    return NULL;
+                    evcands_free(cands);
+                    goto err;
                 }
                 cands_complex[n][i] = cands;
             } else {
                 cands_complex[n][i] =
                     evcands_shift(cands_complex[0][i], offset);
+                if (!cands_complex[n][i]) {
+                    goto err;
+                }
             }
         }
     }
     end = time_ns();
     _info("EVCands Complex Populate: %luus;\n", (end - start) / 1000);
+    evcands_free(base_cands);
     return cands_complex;
+
+err:
+    free_evcands_complex(cands_complex);
+    evcands_free(base_cands);
+    return NULL;
 }
 
 static void shuffle_index(u32 *idxs, u32 sz) {
@@ -166,7 +187,336 @@ static void shuffle_index(u32 *idxs, u32 sz) {
     }
 }
 
+static u32 n_cores(void) {
+    long n = sysconf(_SC_NPROCESSORS_CONF);
+    return n > 0 ? (u32)n : 0;
+}
+
+static bool set_n_para(size_t n) {
+    if (n < 2 || n % 2) {
+        _error("Parallel construction requires an even number of cores >= 2; "
+               "each construction thread needs one helper thread\n");
+        return false;
+    }
+
+    n_para = n;
+    return true;
+}
+
+typedef struct {
+    EVSet ****sfevset_complex;
+    EVSet ***l2evsets;
+    EVCands ***sf_cands;
+    u32 *idxs;
+    u32 n_offsets;
+    u32 next_offset;
+    cache_param *lower_cache;
+    EVBuildConfig *lower_conf;
+    size_t n_lower_evsets;
+    EVBuildConfig base_config;
+    u64 start_time;
+    bool stop;
+    bool failed;
+    pthread_mutex_t work_lock;
+} para_build_ctx;
+
+typedef struct {
+    para_build_ctx *ctx;
+    u32 pair_idx;
+    helper_thread_ctrl hctrl;
+    struct evset_stats stats;
+} para_build_worker;
+
+static void merge_evset_stats(struct evset_stats *dst,
+                              const struct evset_stats *src) {
+    dst->alloc_duration += src->alloc_duration;
+    dst->population_duration += src->population_duration;
+    dst->build_duration += src->build_duration;
+    dst->pruning_duration += src->pruning_duration;
+    dst->extension_duration += src->extension_duration;
+    dst->retries += src->retries;
+    dst->backtracks += src->backtracks;
+    dst->cands_tests += src->cands_tests;
+    dst->mem_accs += src->mem_accs;
+    dst->pure_mem_acc += src->pure_mem_acc;
+    dst->pure_tests += src->pure_tests;
+    dst->pure_mem_acc2 += src->pure_mem_acc2;
+    dst->pure_tests2 += src->pure_tests2;
+    dst->pos_unsure += src->pos_unsure;
+    dst->neg_unsure += src->neg_unsure;
+    dst->ooh += src->ooh;
+    dst->ooc += src->ooc;
+    dst->no_next += src->no_next;
+    dst->timeout += src->timeout;
+    dst->meet += src->meet;
+    dst->retry_duration += src->retry_duration;
+
+    for (u32 i = 0; i < MAX_RETRY_REC; i++) {
+        dst->retry_dist[i] += src->retry_dist[i];
+        dst->useful_retry_dist[i] += src->useful_retry_dist[i];
+        dst->retry_duras[i] += src->retry_duras[i];
+        dst->useful_retry_duras[i] += src->useful_retry_duras[i];
+    }
+    for (u32 i = 0; i < MAX_BACKTRACK_REC; i++) {
+        dst->bctr_dist[i] += src->bctr_dist[i];
+        dst->useful_bctr_dist[i] += src->useful_bctr_dist[i];
+        dst->bctr_duras[i] += src->bctr_duras[i];
+        dst->useful_bctr_duras[i] += src->useful_bctr_duras[i];
+    }
+}
+
+static bool set_thread_affinity(pthread_t thread, u32 core) {
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(core, &set);
+    return pthread_setaffinity_np(thread, sizeof(set), &set) == 0;
+}
+
+static bool next_offset_work(para_build_ctx *ctx, u32 *idx) {
+    bool has_work = false;
+
+    pthread_mutex_lock(&ctx->work_lock);
+    if (!ctx->stop && ctx->next_offset < ctx->n_offsets) {
+        *idx = ctx->next_offset++;
+        has_work = true;
+    }
+    pthread_mutex_unlock(&ctx->work_lock);
+
+    return has_work;
+}
+
+static void request_parallel_stop(para_build_ctx *ctx) {
+    pthread_mutex_lock(&ctx->work_lock);
+    ctx->stop = true;
+    pthread_mutex_unlock(&ctx->work_lock);
+}
+
+static void free_l2evset_complex(EVSet ***complex) {
+    if (!complex) return;
+
+    size_t l2_cnt = cache_uncertainty(detected_l2);
+    EVCands *cands = NULL;
+    for (u32 n = 0; n < NUM_OFFSETS; n++) {
+        if (!complex[n]) continue;
+        for (u32 i = 0; i < l2_cnt; i++) {
+            EVSet *evset = complex[n][i];
+            if (!evset) continue;
+
+            if (!cands) cands = evset->cands;
+            if (n == 0 && evset->config) {
+                _free(evset->config);
+                evset->config = NULL;
+            }
+            evset_free(evset);
+        }
+        _free(complex[n]);
+    }
+    if (cands) evcands_free(cands);
+    _free(complex);
+}
+
+static void free_evcands_complex(EVCands ***complex) {
+    if (!complex) return;
+
+    for (u32 n = 0; n < NUM_OFFSETS; n++) {
+        if (!complex[n]) continue;
+        for (u32 i = 0; i < num_l2sets; i++) {
+            evcands_free(complex[n][i]);
+        }
+        _free(complex[n]);
+    }
+    _free(complex);
+}
+
+static void free_sfevset_complex(EVSet ****complex, size_t l3_cnt) {
+    if (!complex) return;
+
+    for (u32 n = 0; n < NUM_OFFSETS; n++) {
+        if (!complex[n]) continue;
+        for (u32 i = 0; i < num_l2sets; i++) {
+            if (!complex[n][i]) continue;
+            for (u32 j = 0; j < l3_cnt; j++) {
+                EVSet *evset = complex[n][i][j];
+                if (!evset) continue;
+                if (evset->config) {
+                    _free(evset->config);
+                    evset->config = NULL;
+                }
+                evset_free(evset);
+            }
+            _free(complex[n][i]);
+        }
+        _free(complex[n]);
+    }
+    _free(complex);
+}
+
+static void attach_helper_to_sfevsets(EVSet ****complex, u32 *idxs,
+                                      u32 n_offset, size_t l3_cnt,
+                                      helper_thread_ctrl *ctrl) {
+    if (!complex || !ctrl) return;
+
+    for (u32 c = 0; c < n_offset; c++) {
+        u32 n = idxs[c];
+        if (!complex[n]) continue;
+        for (u32 i = 0; i < num_l2sets; i++) {
+            if (!complex[n][i]) continue;
+            for (u32 j = 0; j < l3_cnt; j++) {
+                EVSet *evset = complex[n][i][j];
+                if (!evset || !evset->config) continue;
+                evset->config->test_config.hctrl = ctrl;
+                evset->config->test_config_alt.hctrl = ctrl;
+            }
+        }
+    }
+}
+
+static void *para_build_worker_main(void *arg) {
+    para_build_worker *worker = arg;
+    para_build_ctx *ctx = worker->ctx;
+    EVBuildConfig sf_config = ctx->base_config;
+    size_t l3_cnt;
+    u32 main_core = worker->pair_idx * 2;
+    u32 helper_core = main_core + 1;
+
+    reset_evset_stats();
+
+    if (!set_proc_affinity(main_core)) {
+        _warn("Failed to pin construction thread %u to core %u\n",
+              worker->pair_idx, main_core);
+    }
+
+    if (start_helper_thread(&worker->hctrl)) {
+        pthread_mutex_lock(&ctx->work_lock);
+        ctx->failed = true;
+        ctx->stop = true;
+        pthread_mutex_unlock(&ctx->work_lock);
+        worker->stats = _evset_stats;
+        return NULL;
+    }
+
+    if (!set_thread_affinity(worker->hctrl.pid, helper_core)) {
+        _warn("Failed to pin helper thread %u to core %u\n",
+              worker->pair_idx, helper_core);
+    }
+
+    sf_config.test_config.hctrl = &worker->hctrl;
+    sf_config.test_config_alt.hctrl = &worker->hctrl;
+
+    _info("Pair %u: construction core %u; helper core %u\n",
+          worker->pair_idx, main_core, helper_core);
+
+    for (u32 c = 0; next_offset_work(ctx, &c);) {
+        u32 n = ctx->idxs[c];
+        u32 offset = n * CL_SIZE;
+
+        for (u32 i = 0; i < num_l2sets; i++) {
+            sf_config.test_config.lower_ev = ctx->l2evsets[n][i];
+            EVSet **sf_evsets = build_evsets_at(
+                offset, &sf_config, detected_l3, ctx->sf_cands[n][i],
+                &l3_cnt, ctx->lower_cache, ctx->lower_conf,
+                ctx->l2evsets[n], ctx->n_lower_evsets);
+            ctx->sfevset_complex[n][i] = sf_evsets;
+            if (!sf_evsets) {
+                _error("No sf evsets are built!\n");
+            }
+
+            if (total_runtime_limit &&
+                ((time_ns() - ctx->start_time) / 1e9 >=
+                 total_runtime_limit * 60)) {
+                _error("Timeout break!\n");
+                request_parallel_stop(ctx);
+                break;
+            }
+        }
+
+        _info("Pair %u: offset %#x finished\n", worker->pair_idx, offset);
+    }
+
+    stop_helper_thread(&worker->hctrl);
+    worker->stats = _evset_stats;
+    return NULL;
+}
+
+static bool build_sf_evsets_parallel(EVSet ****sfevset_complex,
+                                     EVSet ***l2evsets,
+                                     EVCands ***sf_cands, u32 *idxs,
+                                     u32 n_offset, EVBuildConfig *sf_config,
+                                     cache_param *lower_cache,
+                                     EVBuildConfig *lower_conf,
+                                     size_t n_lower_evsets,
+                                     u64 start_time) {
+    u32 n_pairs = n_para / 2;
+
+    if (n_pairs > n_offset) {
+        _warn("Only %u page offsets selected; using %u construction pairs "
+              "instead of %u\n",
+              n_offset, n_offset, n_pairs);
+        n_pairs = n_offset;
+    }
+
+    para_build_ctx ctx = {
+        .sfevset_complex = sfevset_complex,
+        .l2evsets = l2evsets,
+        .sf_cands = sf_cands,
+        .idxs = idxs,
+        .n_offsets = n_offset,
+        .next_offset = 0,
+        .lower_cache = lower_cache,
+        .lower_conf = lower_conf,
+        .n_lower_evsets = n_lower_evsets,
+        .base_config = *sf_config,
+        .start_time = start_time,
+        .stop = false,
+        .failed = false,
+    };
+    pthread_mutex_init(&ctx.work_lock, NULL);
+
+    pthread_t *threads = _calloc(n_pairs, sizeof(*threads));
+    para_build_worker *workers = _calloc(n_pairs, sizeof(*workers));
+    if (!threads || !workers) {
+        _error("Failed to allocate parallel construction workers\n");
+        _free(threads);
+        _free(workers);
+        pthread_mutex_destroy(&ctx.work_lock);
+        return false;
+    }
+
+    _info("Starting %u parallel construction pairs\n", n_pairs);
+    for (u32 i = 0; i < n_pairs; i++) {
+        workers[i].ctx = &ctx;
+        workers[i].pair_idx = i;
+        if (pthread_create(&threads[i], NULL, para_build_worker_main,
+                           &workers[i])) {
+            _error("Failed to create construction thread %u\n", i);
+            ctx.failed = true;
+            request_parallel_stop(&ctx);
+            n_pairs = i;
+            break;
+        }
+    }
+
+    struct evset_stats stats = {0};
+    for (u32 i = 0; i < n_pairs; i++) {
+        pthread_join(threads[i], NULL);
+        merge_evset_stats(&stats, &workers[i].stats);
+    }
+    _evset_stats = stats;
+
+    bool success = !ctx.failed;
+    _free(threads);
+    _free(workers);
+    pthread_mutex_destroy(&ctx.work_lock);
+    return success;
+}
+
 int build_sf_evset_all(u32 n_offset) {
+    int ret = EXIT_FAILURE;
+    bool helper_started = false;
+    EVCands ***sf_cands = NULL;
+    EVSet ****sfevset_complex = NULL;
+    size_t l3_cnt = 0;
+
     EVSet ***l2evsets = build_l2_evsets_all();
     if (!l2evsets) {
         _error("Failed to build L2 evset complex\n");
@@ -193,10 +543,10 @@ int build_sf_evset_all(u32 n_offset) {
     sf_config.algo_config.prelim_test = true;
     sf_config.algo_config.extra_cong = extra_cong;
 
-    EVCands ***sf_cands = build_evcands_all(&sf_config, l2evsets);
+    sf_cands = build_evcands_all(&sf_config, l2evsets);
     if (!sf_cands) {
         _error("Failed to allocate or filter SF candidates\n");
-        return EXIT_FAILURE;
+        goto cleanup;
     }
 
     reset_evset_stats();
@@ -204,8 +554,6 @@ int build_sf_evset_all(u32 n_offset) {
     if (single_thread) {
         sf_config.test_config.traverse = skx_sf_cands_traverse_st;
         sf_config.test_config.need_helper = false;
-    } else {
-        start_helper_thread(sf_config.test_config.hctrl);
     }
 
     n_offset = _min(n_offset, NUM_OFFSETS);
@@ -213,10 +561,15 @@ int build_sf_evset_all(u32 n_offset) {
         n_offset = NUM_OFFSETS;
     }
 
-    EVSet ****sfevset_complex = calloc(NUM_OFFSETS, sizeof(*sfevset_complex));
+    l3_cnt = cache_uncertainty(detected_l3);
+    if (sf_config.cands_config.filter_ev) {
+        l3_cnt /= cache_uncertainty(sf_config.cands_config.filter_ev->target_cache);
+    }
+
+    sfevset_complex = calloc(NUM_OFFSETS, sizeof(*sfevset_complex));
     if (!sfevset_complex) {
         _error("Failed to allocate SF complex\n");
-        return EXIT_FAILURE;
+        goto cleanup;
     }
 
     for (u32 n = 0; n < NUM_OFFSETS; n++) {
@@ -224,12 +577,11 @@ int build_sf_evset_all(u32 n_offset) {
             calloc(num_l2sets, sizeof(**sfevset_complex));
         if (!sfevset_complex[n]) {
             _error("Failed to allocate SF sub-complex\n");
-            return EXIT_FAILURE;
+            goto cleanup;
         }
     }
 
     _info("About to start evset construction\n");
-    size_t l3_cnt;
 
     cache_param *lower_cache = NULL;
     EVBuildConfig *lower_conf = NULL;
@@ -240,27 +592,42 @@ int build_sf_evset_all(u32 n_offset) {
         n_lower_evsets = cache_uncertainty(detected_l2);
     }
 
-    u64 start = time_ns(), end;
-    for (u32 c = 0; c < n_offset; c++) {
-        u32 n = idxs[c];
-        u32 offset = n * CL_SIZE;
-        for (u32 i = 0; i < num_l2sets; i++) {
-            sf_config.test_config.lower_ev = l2evsets[n][i];
-            EVSet **sf_evsets = build_evsets_at(
-                offset, &sf_config, detected_l3, sf_cands[n][i], &l3_cnt,
-                lower_cache, lower_conf, l2evsets[n], n_lower_evsets);
-            sfevset_complex[n][i] = sf_evsets;
-            if (!sf_evsets) {
-                _error("No sf evsets are built!\n");
-            }
-
-            if (total_runtime_limit &&
-                ((time_ns() - start) / 1e9 >= total_runtime_limit * 60)) {
-                _error("Timeout break!\n");
-                goto timeout_break;
-            }
+    if (!single_thread && !n_para) {
+        if (start_helper_thread(sf_config.test_config.hctrl)) {
+            goto cleanup;
         }
-        _info("Offset %#x finished\n", offset);
+        helper_started = true;
+    }
+
+    u64 start = time_ns(), end;
+    if (n_para) {
+        if (!build_sf_evsets_parallel(sfevset_complex, l2evsets, sf_cands,
+                                      idxs, n_offset, &sf_config, lower_cache,
+                                      lower_conf, n_lower_evsets, start)) {
+            goto cleanup;
+        }
+    } else {
+        for (u32 c = 0; c < n_offset; c++) {
+            u32 n = idxs[c];
+            u32 offset = n * CL_SIZE;
+            for (u32 i = 0; i < num_l2sets; i++) {
+                sf_config.test_config.lower_ev = l2evsets[n][i];
+                EVSet **sf_evsets = build_evsets_at(
+                    offset, &sf_config, detected_l3, sf_cands[n][i], &l3_cnt,
+                    lower_cache, lower_conf, l2evsets[n], n_lower_evsets);
+                sfevset_complex[n][i] = sf_evsets;
+                if (!sf_evsets) {
+                    _error("No sf evsets are built!\n");
+                }
+
+                if (total_runtime_limit &&
+                    ((time_ns() - start) / 1e9 >= total_runtime_limit * 60)) {
+                    _error("Timeout break!\n");
+                    goto timeout_break;
+                }
+            }
+            _info("Offset %#x finished\n", offset);
+        }
     }
 
 timeout_break:
@@ -268,6 +635,15 @@ timeout_break:
     _info("Finished evset construction\n");
     _info("L3 Duration: %.3fms\n", (end - start) / 1e6);
     pprint_evset_stats();
+
+    if (n_para) {
+        if (start_helper_thread(&hctrl)) {
+            goto cleanup;
+        }
+        helper_started = true;
+        attach_helper_to_sfevsets(sfevset_complex, idxs, n_offset, l3_cnt,
+                                  &hctrl);
+    }
 
     size_t total_succ = 0, total_sf_succ = 0;
     for (u32 c = 0; c < n_offset; c++) {
@@ -309,11 +685,17 @@ timeout_break:
     _info("Aggregated: %lu/%lu/%lu (LLC/SF/Expecting)\n",
           total_succ, total_sf_succ, cache_uncertainty(detected_l3) * n_offset);
 
-    if (!single_thread) {
+    ret = EXIT_SUCCESS;
+
+cleanup:
+    if (helper_started) {
         stop_helper_thread(sf_config.test_config.hctrl);
     }
+    free_sfevset_complex(sfevset_complex, l3_cnt);
+    free_evcands_complex(sf_cands);
+    free_l2evset_complex(l2evsets);
 
-    return EXIT_SUCCESS;
+    return ret;
 }
 
 void handler(int sig, siginfo_t *si, void *unused) {
@@ -332,10 +714,6 @@ void handler(int sig, siginfo_t *si, void *unused) {
 
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        _error("./osc-multi-evset <num_offsets>\n");
-        return EXIT_FAILURE;
-    }
     struct sigaction sa;
 
     memset(&sa, 0, sizeof(struct sigaction));
@@ -346,7 +724,7 @@ int main(int argc, char **argv) {
     sigaction(SIGSEGV, &sa, NULL);
     sigaction(SIGFPE, &sa, NULL);
 
-    u32 n_offset = strtoul(argv[1], NULL, 10);
+    u32 n_offset = 0;
 
     int opt, opt_idx;
     static struct option long_opts[] = {
@@ -358,11 +736,13 @@ int main(int argc, char **argv) {
         {"timeout", required_argument, NULL, 'T'},
         {"algorithm", required_argument, NULL, 'A'},
         {"total-run-time-limit", required_argument, NULL, 'L'}, // in minutes
+        {"parallel-construction", required_argument, NULL, 'P'},
         {0, 0, 0, 0}
     };
 
     char *algo_name = "default";
-    while ((opt = getopt_long(argc, argv, "fsC:B:R:T:A:L:", long_opts,
+    optind = 1;
+    while ((opt = getopt_long(argc, argv, "fsC:B:R:T:A:L:P:", long_opts,
                               &opt_idx)) != -1) {
         switch (opt) {
             case 'f': l2_filter = false; break;
@@ -373,9 +753,49 @@ int main(int argc, char **argv) {
             case 'T': max_timeout = strtoull(optarg, NULL, 10); break;
             case 'A': algo_name = optarg; break;
             case 'L': total_runtime_limit = strtoull(optarg, NULL, 10); break;
+            case 'P': {
+                char *endptr = NULL;
+                size_t n = strtoull(optarg, &endptr, 10);
+                if (endptr == optarg || *endptr != '\0') {
+                    _error("Invalid parallel construction core count: %s\n",
+                           optarg);
+                    return EXIT_FAILURE;
+                }
+                if (n == 0) {
+                    n = n_cores();
+                    if (n % 2) n--;
+                }
+                if (!set_n_para(n)) {
+                    return EXIT_FAILURE;
+                }
+                break;
+            }
             default: _error("Unknown option %c\n", opt); return EXIT_FAILURE;
         }
     }
+
+    if (optind < argc) {
+        char *endptr = NULL;
+        unsigned long parsed = strtoul(argv[optind], &endptr, 10);
+        if (endptr == argv[optind] || *endptr != '\0') {
+            _error("Invalid number of offsets: %s\n", argv[optind]);
+            return EXIT_FAILURE;
+        }
+        n_offset = (u32)parsed;
+        optind++;
+    }
+
+    if (optind < argc) {
+        _error("Unexpected argument: %s\n", argv[optind]);
+        return EXIT_FAILURE;
+    }
+
+    if (n_para && single_thread) {
+        _error("Parallel construction requires helper threads and cannot be "
+               "combined with --single-thread\n");
+        return EXIT_FAILURE;
+    }
+
     evalgo = parse_evset_algo(algo_name);
     if (evalgo == EVSET_ALGO_INVALID) {
         _error("Invalid evset construction algorithm: %s\n", algo_name);

--- a/src/osc-multi-evset.c
+++ b/src/osc-multi-evset.c
@@ -192,10 +192,65 @@ static u32 n_cores(void) {
     return n > 0 ? (u32)n : 0;
 }
 
+static u32 smt_id(u32 cpu) {
+    char path[128];
+    u32 id = cpu;
+    FILE *fp;
+
+    snprintf(path, sizeof(path),
+             "/sys/devices/system/cpu/cpu%u/topology/thread_siblings_list",
+             cpu);
+    fp = fopen(path, "r");
+    if (fp) {
+        if (fscanf(fp, "%u", &id) != 1) id = cpu;
+        fclose(fp);
+    }
+    return id;
+}
+
+static u32 pick_cores(u32 *cores, u32 n_needed) {
+    cpu_set_t allowed;
+    bool check_allowed = sched_getaffinity(0, sizeof(allowed), &allowed) == 0;
+    u32 n_cpu = _min(n_cores(), CPU_SETSIZE);
+    u32 ids[CPU_SETSIZE];
+    u32 n = 0;
+
+    for (u32 cpu = 0; cpu < n_cpu; cpu++) {
+        bool seen = false;
+        u32 id;
+
+        if (check_allowed && !CPU_ISSET(cpu, &allowed)) continue;
+
+        id = smt_id(cpu);
+        for (u32 i = 0; i < n; i++) {
+            if (ids[i] == id) {
+                seen = true;
+                break;
+            }
+        }
+        if (seen) continue;
+
+        ids[n] = id;
+        if (cores) cores[n] = cpu;
+        n++;
+        if (n_needed && n == n_needed) break;
+    }
+
+    return n;
+}
+
 static bool set_n_para(size_t n) {
     if (n < 2 || n % 2) {
         _error("Parallel construction requires an even number of cores >= 2; "
                "each construction thread needs one helper thread\n");
+        return false;
+    }
+
+    u32 n_avail = pick_cores(NULL, 0);
+    if (n > n_avail) {
+        _error("Need %lu non-SMT cores for parallel construction; only %u "
+               "available\n",
+               n, n_avail);
         return false;
     }
 
@@ -207,6 +262,7 @@ typedef struct {
     EVSet ****sfevset_complex;
     EVSet ***l2evsets;
     EVCands ***sf_cands;
+    u32 *cores;
     u32 *idxs;
     u32 n_offsets;
     u32 next_offset;
@@ -376,8 +432,8 @@ static void *para_build_worker_main(void *arg) {
     para_build_ctx *ctx = worker->ctx;
     EVBuildConfig sf_config = ctx->base_config;
     size_t l3_cnt;
-    u32 main_core = worker->pair_idx * 2;
-    u32 helper_core = main_core + 1;
+    u32 main_core = ctx->cores[worker->pair_idx * 2];
+    u32 helper_core = ctx->cores[worker->pair_idx * 2 + 1];
 
     reset_evset_stats();
 
@@ -455,10 +511,24 @@ static bool build_sf_evsets_parallel(EVSet ****sfevset_complex,
         n_pairs = n_offset;
     }
 
+    u32 n_pinned = n_pairs * 2;
+    u32 *cores = _calloc(n_pinned, sizeof(*cores));
+    if (!cores) {
+        _error("Failed to allocate core list\n");
+        return false;
+    }
+
+    if (pick_cores(cores, n_pinned) != n_pinned) {
+        _error("Need %u non-SMT cores for parallel construction\n", n_pinned);
+        _free(cores);
+        return false;
+    }
+
     para_build_ctx ctx = {
         .sfevset_complex = sfevset_complex,
         .l2evsets = l2evsets,
         .sf_cands = sf_cands,
+        .cores = cores,
         .idxs = idxs,
         .n_offsets = n_offset,
         .next_offset = 0,
@@ -478,6 +548,7 @@ static bool build_sf_evsets_parallel(EVSet ****sfevset_complex,
         _error("Failed to allocate parallel construction workers\n");
         _free(threads);
         _free(workers);
+        _free(cores);
         pthread_mutex_destroy(&ctx.work_lock);
         return false;
     }
@@ -506,6 +577,7 @@ static bool build_sf_evsets_parallel(EVSet ****sfevset_complex,
     bool success = !ctx.failed;
     _free(threads);
     _free(workers);
+    _free(cores);
     pthread_mutex_destroy(&ctx.work_lock);
     return success;
 }
@@ -762,7 +834,7 @@ int main(int argc, char **argv) {
                     return EXIT_FAILURE;
                 }
                 if (n == 0) {
-                    n = n_cores();
+                    n = pick_cores(NULL, 0);
                     if (n % 2) n--;
                 }
                 if (!set_n_para(n)) {

--- a/src/osc-multi-evset.c
+++ b/src/osc-multi-evset.c
@@ -13,6 +13,7 @@ static size_t extra_cong = 1;
 static size_t max_tries = 10, max_backtrack = 20, max_timeout = 0;
 static size_t total_runtime_limit = 0; // in minutes
 static bool l2_filter = true, single_thread = false;
+static bool no_pin = false;
 static size_t n_para = 0;
 static size_t num_l2sets;
 static helper_thread_ctrl hctrl;
@@ -437,7 +438,7 @@ static void *para_build_worker_main(void *arg) {
 
     reset_evset_stats();
 
-    if (!set_proc_affinity(main_core)) {
+    if (!no_pin && !set_proc_affinity(main_core)) {
         _warn("Failed to pin construction thread %u to core %u\n",
               worker->pair_idx, main_core);
     }
@@ -451,7 +452,7 @@ static void *para_build_worker_main(void *arg) {
         return NULL;
     }
 
-    if (!set_thread_affinity(worker->hctrl.pid, helper_core)) {
+    if (!no_pin && !set_thread_affinity(worker->hctrl.pid, helper_core)) {
         _warn("Failed to pin helper thread %u to core %u\n",
               worker->pair_idx, helper_core);
     }
@@ -459,8 +460,10 @@ static void *para_build_worker_main(void *arg) {
     sf_config.test_config.hctrl = &worker->hctrl;
     sf_config.test_config_alt.hctrl = &worker->hctrl;
 
-    _info("Pair %u: construction core %u; helper core %u\n",
-          worker->pair_idx, main_core, helper_core);
+    if (!no_pin) {
+        _info("Pair %u: construction core %u; helper core %u\n",
+              worker->pair_idx, main_core, helper_core);
+    }
 
     for (u32 c = 0; next_offset_work(ctx, &c);) {
         u32 n = ctx->idxs[c];
@@ -809,6 +812,7 @@ int main(int argc, char **argv) {
         {"algorithm", required_argument, NULL, 'A'},
         {"total-run-time-limit", required_argument, NULL, 'L'}, // in minutes
         {"parallel-construction", required_argument, NULL, 'P'},
+        {"no-pin", no_argument, NULL, 0},
         {0, 0, 0, 0}
     };
 
@@ -817,6 +821,11 @@ int main(int argc, char **argv) {
     while ((opt = getopt_long(argc, argv, "fsC:B:R:T:A:L:P:", long_opts,
                               &opt_idx)) != -1) {
         switch (opt) {
+            case 0:
+                if (strcmp(long_opts[opt_idx].name, "no-pin") == 0) {
+                    no_pin = true;
+                }
+                break;
             case 'f': l2_filter = false; break;
             case 's': single_thread = true; break;
             case 'C': cands_scaling = strtod(optarg, NULL); break;


### PR DESCRIPTION
The idea is to enable the parallel eviction set construction 
of eviction sets by having each constructor/helper thread 
work on candidates of different page offsets without 
interfering in the cache due to overlapping or conflicting 
accesses (since each offset maps to its separate potential 
sets in the LLC).

The `README` includes instructions on how to use the new `-P`
param to control the parallel (para) mode.

The same idea can apply to spawn parallel working pairs 
at each L2 uncertain evset used for filtering, though 
is not addressed in this PR.

### AI-generated content
These functions:
* `free_evcands_complex`
* `free_sfevset_complex`
* `free_l2evset_complex`

With Codex (GPT 5.5 Extra High Reasoning)

### Handwritten conten
Pretty much everything else. Though I had Codex go 
over my code and find cases of poor err handling or 
mem management and harden them.